### PR TITLE
I've updated the README.md to the standard scaffold-eth format.

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ const { data: someData } = useScaffoldReadContract({
 
 ### Writing data to a contract
 Use the `useScaffoldWriteContract` (`packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts`) hook.
-1. Initilize the hook with just the contract name
+1. Initialize the hook with just the contract name
 2. Call the `writeContractAsync` function.
 
 Example:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The usual dev flow is:
 - Iterate until you get the functionality you want in your contract
 - Write tests for the contract in `packages/hardhat/test`
 - Create your custom UI using all the SE-2 components, hooks, and utilities.
-- Deploy your Smart Contrac to a live network
+- Deploy your Smart Contract to a live network
 - Deploy your UI (`yarn vercel` or `yarn ipfs`)
   - You can tweak which network the frontend is pointing (and some other configurations) in `scaffold.config.ts`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ The usual dev flow is:
   - `yarn start`: Starts the frontend
 - Write a Smart Contract (modify the deployment script in `packages/hardhat/deploy` if needed)
 - Deploy it locally (`yarn deploy`)
-- Go to the `http://locahost:3000/debug` page to interact with your contract with a nice UI
+- Go to the `http://localhost:3000/debug` page to interact with your contract with a nice UI
 - Iterate until you get the functionality you want in your contract
 - Write tests for the contract in `packages/hardhat/test`
 - Create your custom UI using all the SE-2 components, hooks, and utilities.

--- a/README.md
+++ b/README.md
@@ -1,28 +1,79 @@
-# EvilMegacorp-ETH.Global.Prague
-Project for ETH Global Hackaton Prague 2025
-+++++++++++++++++++++++++++++++++++++++++++
-}}EVIL MEGACORP{{
- you are a number
- 
-------------------
-I will use Scaffold ETH 2, since that's what we learned with in Urbe Bootcamp at 42 Prague.
-.
-The idea is to create and authentication and privilege system for Evil Megacorp.
-Permission to mint NFT auth key will be given to wallets stored in CAN MINT LIST (in AUTH Smart contract ?? // COSTS!
-Only highest clearance 7 users can add addresses to CAN MINT LIST. Only on the condition the user is not already in CHAIN.
-Once address minted an NFT it is deleted from the CAN MINT LIST and added to the CHAIN of users.. gets it's number in the row and clearance level.
-Clearance 7 can add clearance 6 users. Top clearance (owner) can give any clearance.
-Once key is minted, clearance level can be adjusted by owner.
-0xADD7355   6           0x5044EADD7E55
+---
+description:
+globs:
+alwaysApply: true
+---
 
-CHAIN:
-No:(line number) ADDRESS:        AUTH VECTOR:  CLEARANCE:
-1                0x5044EADD7E55  uint256       F
-2                
-3
+This codebase contains Scaffold-ETH 2 (SE-2), everything you need to build dApps on Ethereum. Its tech stack is NextJS, RainbowKit, Wagmi and Typescript. Supports Hardhat and Foundry.
 
-Login:
-1/ Connect Wallet - Verify ownership of NFT
-2/ Scan Face      
-3/ Enter code<<<<???????
+It's a yarn monorepo that contains following packages:
 
+- HARDHAT (`packages/hardhat`): The solidity framework to write, test and deploy EVM Smart Contracts.
+- NextJS (`packages/nextjs`): The UI framework extended with utilities to make interacting with Smart Contracts easy (using Next.js App Router, not Pages Router).
+
+
+The usual dev flow is:
+
+- Start SE-2 locally:
+  - `yarn chain`: Starts a local blockchain network
+  - `yarn deploy`: Deploys SE-2 default contract
+  - `yarn start`: Starts the frontend
+- Write a Smart Contract (modify the deployment script in `packages/hardhat/deploy` if needed)
+- Deploy it locally (`yarn deploy`)
+- Go to the `http://locahost:3000/debug` page to interact with your contract with a nice UI
+- Iterate until you get the functionality you want in your contract
+- Write tests for the contract in `packages/hardhat/test`
+- Create your custom UI using all the SE-2 components, hooks, and utilities.
+- Deploy your Smart Contrac to a live network
+- Deploy your UI (`yarn vercel` or `yarn ipfs`)
+  - You can tweak which network the frontend is pointing (and some other configurations) in `scaffold.config.ts`
+
+## Smart Contract UI interactions guidelines
+SE-2 provides a set of hooks that facilitates contract interactions from the UI. It reads the contract data from `deployedContracts.ts` and `externalContracts.ts`, located in `packages/nextjs/contracts`.
+
+### Reading data from a contract
+Use the `useScaffoldReadContract` (`packages/nextjs/hooks/scaffold-eth/useScaffoldReadContract.ts`) hook.
+
+Example:
+```typescript
+const { data: someData } = useScaffoldReadContract({
+  contractName: "YourContract",
+  functionName: "functionName",
+  args: [arg1, arg2], // optional
+});
+```
+
+### Writing data to a contract
+Use the `useScaffoldWriteContract` (`packages/nextjs/hooks/scaffold-eth/useScaffoldWriteContract.ts`) hook.
+1. Initilize the hook with just the contract name
+2. Call the `writeContractAsync` function.
+
+Example:
+```typescript
+const { writeContractAsync: writeYourContractAsync } = useScaffoldWriteContract(
+  { contractName: "YourContract" }
+);
+// Usage (this will send a write transaction to the contract)
+await writeContractAsync({
+  functionName: "functionName",
+  args: [arg1, arg2], // optional
+  value: parseEther("0.1"), // optional, for payable functions
+});
+```
+
+Never use any other patterns for contract interaction. The hooks are:
+- useScaffoldReadContract (for reading)
+- useScaffoldWriteContract (for writing)
+
+### Other Hooks
+SE-2 also provides other hooks to interact with blockchain data: `useScaffoldWatchContractEvent`, `useScaffoldEventHistory`, `useDeployedContractInfo`, `useScaffoldContract`, `useTransactor`. They live under `packages/nextjs/hooks/scaffold-eth`.
+## Display Components guidelines
+SE-2 provides a set of pre-built React components for common Ethereum use cases:
+- `Address`: Always use this when displaying an ETH address
+- `AddressInput`: Always use this when users need to input an ETH address
+- `Balance`: Display the ETH/USDC balance of a given address
+- `EtherInput`: An extended number input with ETH/USD conversion.
+
+They live under `packages/nextjs/components/scaffold-eth`.
+
+Find the relevant information from the documentation and the codebase. Think step by step before answering the question.


### PR DESCRIPTION
The previous README.md appeared to be a brainstorming document. This change replaces it with the standard scaffold-eth README content, providing an overview of the project structure, development flow, and guidelines for smart contract interaction and UI components.